### PR TITLE
ヘッダーの設置とボタンの設置 fixes #8

### DIFF
--- a/app/assets/images/sample.png
+++ b/app/assets/images/sample.png
@@ -1,0 +1,1 @@
+https://img.esa.io/uploads/production/attachments/2315/2019/05/22/53778/0b16e705-5c18-4a75-aa15-cc6260bd8db3.jpg

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,3 @@
+class StaticPagesController < ApplicationController
+  def top; end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Myapp</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>RUNTEQ BOARD APP</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <%= stylesheet_link_tag "application" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 
   <body>
+    <%= render 'shared/header' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,33 @@
+<header>
+  <nav class='navbar navbar-expand-lg navigation navbar-light bg-light'>
+    <%= link_to '/', class: 'navbar-brand' do %>
+      <%= '🏠' %>
+    <% end %>
+    <button class='navbar-toggler' data-bs-toggle='collapse' data-bs-target='#navbarSupportedContent'
+      aria-controls='navbarSupportedContent' aria-expanded='false' aria-label='Toggle navigation'>
+      <span class='navbar-toggler-icon'></span>
+    </button>
+
+    <div class='collapse navbar-collapse' id='navbarSupportedContent'>
+      <ul class='navbar-nav ms-auto main-nav align-items-center'>
+        
+
+        <li class='nav-item'>
+          <%= link_to '➕', '#', class: 'nav-link' %>
+        </li>
+
+        <li class='nav-item dropdown dropdown-slide'>
+          <%= link_to '#', class: 'nav-link', data: { bs_toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, id: 'header-profile' do %>
+            <%= '🧏' %>
+          <% end %>
+          <div class='dropdown-menu dropdown-menu-end'>
+            <div class='dropdown-item'>@user_name</div>
+            <div class='dropdown-divider'></div>
+            <%= link_to 'プロフィール', '#', class: 'dropdown-item' %>
+            <%= link_to 'ログアウト', '#', class: 'dropdown-item' %>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,5 @@
+<div class="top-wrapper">
+  <div class="top-inner-text">
+    <h1>投稿一覧(仮)</h1>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  # get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
   # root "posts#index"
+   root 'static_pages#top'
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- app/views/shared/_header.html.erbでヘッダーのパーシャルファイルの作成、編集
- ルーティング(root 'static_pages#top')
- static_pages_controllerの作成、編集
- static_pages/top.html.erbの作成、編集
- app/views/layouts/application.html.erbにrenderメソッドで_header.html.erbの表示

- [x] 上記実装しました。
- [x] ホームボタンは #31 、新規投稿ボタン、アイコンボタンのCSSについては #29 で実装します。