### PR TITLE
postの画像アップロード機能の追加 fixes #22

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ gem "oauth2", "~> 2.0.9"
 
 # Optional bcrypt for user authentication
 gem "bcrypt", "~> 3.1.7"
+
+gem 'carrierwave', '2.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (2.2.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -109,11 +117,16 @@ GEM
       logger
     faraday-net_http (3.1.1)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -136,6 +149,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
@@ -223,6 +237,9 @@ GEM
       io-console (~> 0.5)
     rexml (3.3.2)
       strscan
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     selenium-webdriver (4.23.0)
       base64 (~> 0.2)
@@ -244,6 +261,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.1)
@@ -280,6 +298,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   capybara
+  carrierwave (= 2.2.2)
   cssbundling-rails
   debug
   jbuilder

--- a/app/assets/images/post_placeholder.png
+++ b/app/assets/images/post_placeholder.png
@@ -1,0 +1,1 @@
+https://user-images.githubusercontent.com/10973259/70017892-c40bbc00-15c7-11ea-8022-9cb7e5d22aa1.png

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,6 +21,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:place_name, :adress, :body)
+    params.require(:post).permit(:place_name, :adress, :body, :post_image, :post_image_cache)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,4 +4,5 @@ class Post < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535 }
 
   belongs_to :user
+  mount_uploader :post_image, PostImageUploader
 end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -1,0 +1,48 @@
+class PostImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  def default_url
+    'post_placeholder'
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/posts/_1post.html.erb
+++ b/app/views/posts/_1post.html.erb
@@ -1,7 +1,7 @@
 <div class="col-sm-12 col-lg-4 mb-3">
               <div id="post-id-<%= post.id %>">
                 <div class="card">
-                  <%= image_tag "#", class: "card-img-top", width: "300", height:"200" %>
+                  <%= image_tag post.post_image_url, class: "card-img-top", width: "300", height:"200" %>
                   <div class="card-body">
                     <div class="d-flex">
                       <h4 class="card-title">

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -4,6 +4,11 @@
       <h1><%= '新規投稿' %></h1>
       <%= form_with model: @post, class: "new_post" do |f| %>
         <div class="mb-3">
+          <%= f.label :post_image %>
+          <%= f.file_field :post_image, class: "form-control", accept: 'image/*' %>
+          <%= f.hidden_field :post_image_cache %>
+        </div>
+        <div class="mb-3">
           <%= f.label :place_name %>
           <%= f.text_field :place_name, class: "form-control" %>
         </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module Myapp
       g.test_framework nil
     end
 
-    config.i18n.default_locale = :ja
+    # config.i18n.default_locale = :ja
     
     config.time_zone = 'Tokyo'
   end

--- a/db/migrate/20240731074641_add_post_image_to_posts.rb
+++ b/db/migrate/20240731074641_add_post_image_to_posts.rb
@@ -1,0 +1,5 @@
+class AddPostImageToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :post_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_31_042714) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_31_074641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_31_042714) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "post_image"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
- [x] gem 'carrierwave'の追加
ファイルアップロードを簡単に行うためのRubyライブラリ。
***

- [x] app/uploaders/post_image_uploader.rb作成、編集
$ rails generate uploader PostImage

- アップロードできるファイルの編集(コメントアウト)
- ファイルがアップロードされていない場合にデフォルトで表示する画像のURL指定

***

- Postsテーブル
- [x] post_imageカラムを追加するマイグレーションファイルの作成、編集
$ rails g migration add_post_image_to_posts post_image:string

- [x] CarrierWave の アップローダークラス（BoardImageUploader）をマウントします
***

- [x] 新規投稿ページに画像アップロード機能を表示

- new.html.erbの編集
- postコントローラーのpost_paramsに追記


